### PR TITLE
Added Suppliers.memoize examples

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,7 +7,7 @@ ext {
         logback           : '1.1.8',       // Logging
         undertow          : '1.4.18.Final', // Webserver
         metrics           : '3.1.2',       // Metrics
-        guava             : '22.0',        // Common / Helper libraries
+        guava             : '23.0',        // Common / Helper libraries
         typesafeConfig    : '1.3.1',       // Configuration
         handlebars        : '4.0.6',       // HTML templating
         htmlCompressor    : '1.4',         // HTML compression

--- a/stubbornjava-examples/src/main/java/com/stubbornjava/examples/common/SuppliersExamples.java
+++ b/stubbornjava-examples/src/main/java/com/stubbornjava/examples/common/SuppliersExamples.java
@@ -1,0 +1,45 @@
+package com.stubbornjava.examples.common;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Suppliers;
+
+public class SuppliersExamples {
+    private static final Logger log = LoggerFactory.getLogger(SuppliersExamples.class);
+
+    // {{start:supplier}}
+    public static String helloWorldSupplier() {
+        log.info("supplying");
+        return "hello world";
+    }
+    // {{end:supplier}}
+
+    public static void main(String[] args) throws InterruptedException {
+        // {{start:memoize}}
+        log.info("Memoized");
+        Supplier<String> memoized = Suppliers.memoize(SuppliersExamples::helloWorldSupplier);
+        log.info(memoized.get());
+        log.info(memoized.get());
+        // {{end:memoize}}
+
+        // {{start:memoizeWithExpiration}}
+        log.info("Memoized with Expiration");
+        Supplier<String> memoizedExpiring = Suppliers.memoizeWithExpiration(
+            SuppliersExamples::helloWorldSupplier, 50, TimeUnit.MILLISECONDS);
+        log.info(memoizedExpiring.get());
+        log.info(memoizedExpiring.get());
+        log.info("sleeping");
+        TimeUnit.MILLISECONDS.sleep(100);
+        log.info(memoizedExpiring.get());
+        log.info(memoizedExpiring.get());
+        log.info("sleeping");
+        TimeUnit.MILLISECONDS.sleep(100);
+        log.info(memoizedExpiring.get());
+        log.info(memoizedExpiring.get());
+        // {{end:memoizeWithExpiration}}
+    }
+}


### PR DESCRIPTION
https://github.com/StubbornJava/StubbornJava/issues/37 Examples for lazy loading / caching objects in Java with Guava's `Suppliers.memoize`